### PR TITLE
Log formatting and lograge enabling

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ And add a show view for this controller:
 </div>
 ```
 
+
 ### Override Bootstrap Variables
 
 You can easily override any bootstrap variable using environment variables:
@@ -340,6 +341,39 @@ It is also included if you import the default stylesheet:
 
 @import "ood_appkit";
 ```
+
+### Custom Log Formatting
+
+A custom log formatter is provided, along with lograge, to both reduce the
+amount of unnecessary logging in production but properly prefix each log with
+timestamp, log severity, and the name of the application. By default
+`enable_log_formatter` is set to true for the production environment, but you
+can turn it on all the time by using an initializer:
+
+```ruby
+# config/initializers/ood_appkit.rb
+
+OodAppkit.configure do |config|
+  # Default
+  config.enable_log_formatter = true
+end
+```
+
+This does several things things:
+
+1. enable lograge
+2. call `OodAppkit::LogFormatter.setup` which
+
+    * sets the formatter of the Rails logger to an instance of OodAppkit::LogFormatter
+    * and sets the `progname` of the Rails logger to the `APP_TOKEN` env var if it is set
+
+
+In production, a single log will look like:
+
+```
+[2016-06-20 10:23:59 -0400 sys/dashboard]  INFO method=GET path=/pun/dev/dashboard/ format=html controller=dashboard action=index status=200 duration=297.15 view=290.20 
+```
+
 
 ## Branding Features
 

--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ This does several things things:
 In production, a single log will look like:
 
 ```
-[2016-06-20 10:23:59 -0400 sys/dashboard]  INFO method=GET path=/pun/dev/dashboard/ format=html controller=dashboard action=index status=200 duration=297.15 view=290.20 
+[2016-06-20 10:23:59 -0400 sys/dashboard]  "INFO method=GET path=/pun/dev/dashboard/ format=html controller=dashboard action=index status=200 duration=297.15 view=290.20"
 ```
 
 

--- a/lib/ood_appkit.rb
+++ b/lib/ood_appkit.rb
@@ -8,6 +8,7 @@ require 'ood_appkit/shell_url'
 require 'ood_appkit/files_url'
 require 'ood_appkit/files_rack_app'
 require 'ood_appkit/markdown_template_handler'
+require 'ood_appkit/log_formatter'
 
 # The main namespace for OodAppkit. Provides a global configuration.
 module OodAppkit

--- a/lib/ood_appkit/configuration.rb
+++ b/lib/ood_appkit/configuration.rb
@@ -101,7 +101,7 @@ module OodAppkit
       )
       ENV.each {|k, v| /^BOOTSTRAP_(?<name>.+)$/ =~ k ? self.bootstrap[name.downcase] = v : nil}
 
-      self.use_ood_log_formatting = true
+      self.use_ood_log_formatting = ::Rails.env.production?
     end
 
     def setup_ood_log_formatting
@@ -119,8 +119,6 @@ module OodAppkit
       end
 
       ::Rails.logger.progname = ENV['APP_TOKEN'] if ENV['APP_TOKEN']
-
-      #TODO: also include lograge AND enable lograge for production env
     end
   end
 end

--- a/lib/ood_appkit/configuration.rb
+++ b/lib/ood_appkit/configuration.rb
@@ -42,7 +42,7 @@ module OodAppkit
     # Set to false if you don't want Rails.logger formatter
     # to use LogFormatter and lograge to be enabled automatically
     # @return [boolean] whether to use OodAppkit log formatting in production
-    attr_accessor :use_ood_log_formatting
+    attr_accessor :enable_log_formatter
 
     # Customize configuration for this object.
     # @yield [self]
@@ -101,24 +101,7 @@ module OodAppkit
       )
       ENV.each {|k, v| /^BOOTSTRAP_(?<name>.+)$/ =~ k ? self.bootstrap[name.downcase] = v : nil}
 
-      self.use_ood_log_formatting = ::Rails.env.production?
-    end
-
-    def setup_ood_log_formatting
-      ::Rails.logger.formatter = LogFormatter.new
-
-      # ActiveSupport::TaggedLogging.new calls
-      #
-      #     logger.formatter.extend(Formatter)
-      #
-      # in an undocumented submodule ActiveSupport::TaggedLogging::Formatter.
-      # So to modify a TaggedLogging logger with another formatter we must
-      # extend our formatter in the same way.
-      if defined?( ActiveSupport::TaggedLogging  ) && ::Rails.logger.kind_of?( ActiveSupport::TaggedLogging )
-        ::Rails.logger.formatter.extend(ActiveSupport::TaggedLogging::Formatter)
-      end
-
-      ::Rails.logger.progname = ENV['APP_TOKEN'] if ENV['APP_TOKEN']
+      self.enable_log_formatter = ::Rails.env.production?
     end
   end
 end

--- a/lib/ood_appkit/engine.rb
+++ b/lib/ood_appkit/engine.rb
@@ -6,11 +6,19 @@ module OodAppkit
       OodAppkit.set_default_configuration
     end
 
-    # Confirm the `OodAppkit.dataroot` configuration option was set
+    # enable lograge if gem available
+    initializer "lograge" do |app|
+      if OodAppkit.use_ood_log_formatting && app.config.respond_to?(:lograge)
+        app.config.lograge.enabled = true
+      end
+    end
+
     config.after_initialize do
+      # Confirm the `OodAppkit.dataroot` configuration option was set
       raise UndefinedDataroot, "OodAppkit.dataroot must be defined (default: ENV['OOD_DATAROOT'])" unless OodAppkit.dataroot
 
-      OodAppkit.setup_ood_log_formatting if OodAppkit.use_ood_log_formatting && ::Rails.env.production?
+      # setup logger to use proper formatter and set progname
+      OodAppkit.setup_ood_log_formatting if OodAppkit.use_ood_log_formatting
     end
 
     # An exception raised when `OodAppkit.dataroot` configuration option is undefined

--- a/lib/ood_appkit/engine.rb
+++ b/lib/ood_appkit/engine.rb
@@ -1,3 +1,5 @@
+require 'lograge'
+
 module OodAppkit
   # The Rails Engine that defines the OodAppkit environment
   class Engine < Rails::Engine
@@ -8,7 +10,8 @@ module OodAppkit
 
     # enable lograge if gem available
     initializer "lograge" do |app|
-      if OodAppkit.enable_log_formatter && app.config.respond_to?(:lograge)
+      if OodAppkit.enable_log_formatter
+        # enable lograge to use with formatter
         app.config.lograge.enabled = true
       end
     end

--- a/lib/ood_appkit/engine.rb
+++ b/lib/ood_appkit/engine.rb
@@ -9,12 +9,8 @@ module OodAppkit
     # Confirm the `OodAppkit.dataroot` configuration option was set
     config.after_initialize do
       raise UndefinedDataroot, "OodAppkit.dataroot must be defined (default: ENV['OOD_DATAROOT'])" unless OodAppkit.dataroot
-    end
 
-    config.to_prepare do
-      # TODO:
-      # make the helper available to all views
-      # i.e. ApplicationController.helper(OodBannerHelper)
+      OodAppkit.setup_ood_log_formatting if OodAppkit.use_ood_log_formatting && ::Rails.env.production?
     end
 
     # An exception raised when `OodAppkit.dataroot` configuration option is undefined

--- a/lib/ood_appkit/engine.rb
+++ b/lib/ood_appkit/engine.rb
@@ -8,7 +8,7 @@ module OodAppkit
 
     # enable lograge if gem available
     initializer "lograge" do |app|
-      if OodAppkit.use_ood_log_formatting && app.config.respond_to?(:lograge)
+      if OodAppkit.enable_log_formatter && app.config.respond_to?(:lograge)
         app.config.lograge.enabled = true
       end
     end
@@ -18,7 +18,7 @@ module OodAppkit
       raise UndefinedDataroot, "OodAppkit.dataroot must be defined (default: ENV['OOD_DATAROOT'])" unless OodAppkit.dataroot
 
       # setup logger to use proper formatter and set progname
-      OodAppkit.setup_ood_log_formatting if OodAppkit.use_ood_log_formatting
+      LogFormatter.setup if OodAppkit.enable_log_formatter
     end
 
     # An exception raised when `OodAppkit.dataroot` configuration option is undefined

--- a/lib/ood_appkit/log_formatter.rb
+++ b/lib/ood_appkit/log_formatter.rb
@@ -3,7 +3,7 @@ module OodAppkit
   #
   #     [2016-06-17 15:31:01 -0400 sys/dashboard]  INFO  GET...
   #
-  class LogFormatter < ActiveSupport::Logger::SimpleFormatter
+  class LogFormatter
     def call(severity, timestamp, progname, msg)
       severity_d = severity ? severity[0,5].rjust(5).upcase : "UNKNO"
       timestamp_d = timestamp ? timestamp.localtime : Time.now.localtime

--- a/lib/ood_appkit/log_formatter.rb
+++ b/lib/ood_appkit/log_formatter.rb
@@ -11,5 +11,24 @@ module OodAppkit
 
       "[#{timestamp_d} #{progname}] #{severity_d} #{msg_d}\n"
     end
+
+    # make the Rails logger use this class for the formatter
+    # and set the progname to be the app token
+    def self.setup
+      ::Rails.logger.formatter = LogFormatter.new
+
+      # ActiveSupport::TaggedLogging.new calls
+      #
+      #     logger.formatter.extend(Formatter)
+      #
+      # in an undocumented submodule ActiveSupport::TaggedLogging::Formatter.
+      # So to modify a TaggedLogging logger with another formatter we must
+      # extend our formatter in the same way.
+      if defined?( ActiveSupport::TaggedLogging  ) && ::Rails.logger.kind_of?( ActiveSupport::TaggedLogging )
+        ::Rails.logger.formatter.extend(ActiveSupport::TaggedLogging::Formatter)
+      end
+
+      ::Rails.logger.progname = ENV['APP_TOKEN'] if ENV['APP_TOKEN']
+    end
   end
 end

--- a/lib/ood_appkit/log_formatter.rb
+++ b/lib/ood_appkit/log_formatter.rb
@@ -7,7 +7,7 @@ module OodAppkit
     def call(severity, timestamp, progname, msg)
       severity_d = severity ? severity[0,5].rjust(5).upcase : "UNKNO"
       timestamp_d = timestamp ? timestamp.localtime : Time.now.localtime
-      msg_d = (String === msg ? msg.strip : msg.inspect)
+      msg_d = (String === msg ? msg.strip.inspect : msg.inspect)
 
       "[#{timestamp_d} #{progname}] #{severity_d} #{msg_d}\n"
     end

--- a/lib/ood_appkit/log_formatter.rb
+++ b/lib/ood_appkit/log_formatter.rb
@@ -1,0 +1,15 @@
+module OodAppkit
+  # format log messages with timestamp severity and app token e.g.:
+  #
+  #     [2016-06-17 15:31:01 -0400 sys/dashboard]  INFO  GET...
+  #
+  class LogFormatter < ActiveSupport::Logger::SimpleFormatter
+    def call(severity, timestamp, progname, msg)
+      severity_d = severity ? severity[0,5].rjust(5).upcase : "UNKNO"
+      timestamp_d = timestamp ? timestamp.localtime : Time.now.localtime
+      msg_d = (String === msg ? msg.strip : msg.inspect)
+
+      "[#{timestamp_d} #{progname}] #{severity_d} #{msg_d}\n"
+    end
+  end
+end

--- a/ood_appkit.gemspec
+++ b/ood_appkit.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", "~> 4.0"
   s.add_dependency "addressable", "~> 2.4"
   s.add_dependency "redcarpet", "~> 3.2"
+  s.add_dependency "lograge", "~>0.3"
 
   s.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
Fixes #https://github.com/AweSim-OSC/osc-ondemand/issues/85

If `OodAppkit.use_ood_log_formatting` is set to true in an initializer, then we do these things:

1. set the log formatter of the `Rails.logger` to `OodAppkit::LogFormatter.new`
2. set the `progname` of the `Rails.logger` to the app token (if it exists)
3. enable lograge if the config option is available

By default this is enabled in production. The log formatter prepends logs with timestamp, app token, and log level. For example, here is a single request:

```
[2016-06-17 18:12:17 -0400 efranz/dashboard]  INFO method=GET path=/pun/dev/dashboard/ format=html controller=dashboard action=index status=200 duration=289.55 view=278.56
```

This addresses https://github.com/AweSim-OSC/osc-ondemand/issues/85

NOTE: I wanted to use the Rails config option `log_formatter` but that was not working when I set it from the engine. I tried multiple things, including `::Rails.configuration.log_formatter = OodAppkit::LogFormatter.new` in the `before_initialize` section and `config.log_formatter`. I end up with something like this:

```
irb(main):005:0> Rails.configuration.log_formatter
=> #<OodAppkit::LogFormatter:0x00000002b4f788>
irb(main):006:0> Rails.logger.formatter
=> #<ActiveSupport::Logger::SimpleFormatter:0x00000003ee2110 @datetime_format=nil>
```

Using the log_formatter option in the future would be preferable to the `Rails.logger.formatter.extend` line in the future.