### PR TITLE
Set default cookie options

### DIFF
--- a/lib/ood_appkit.rb
+++ b/lib/ood_appkit.rb
@@ -4,6 +4,7 @@ require 'ood_appkit/url'
 require 'ood_appkit/files_rack_app'
 require 'ood_appkit/markdown_template_handler'
 require 'ood_appkit/log_formatter'
+require 'ood_appkit/default_cookie_options'
 
 # The main namespace for OodAppkit. Provides a global configuration.
 module OodAppkit

--- a/lib/ood_appkit/default_cookie_options.rb
+++ b/lib/ood_appkit/default_cookie_options.rb
@@ -1,0 +1,12 @@
+module OodAppkit
+  module DefaultCookieOptions
+    def handle_options(options)
+      if base_uri = ENV["RAILS_RELATIVE_URL_ROOT"]
+        options[:path] = base_uri unless /^#{Regexp.quote base_uri}/ =~ options[:path]
+      end
+      super(options)
+    end
+  end
+end
+
+ActionDispatch::Cookies::CookieJar.prepend OodAppkit::DefaultCookieOptions


### PR DESCRIPTION
Fixes #34

Assume:

```bash
RAILS_RELATIVE_URL_ROOT="/pun/sys/myjobs"
```

All cookies (including session cookies) will have their path set to:

```
/pun/sys/myjobs
```

unless the app requests a deeper path such as:

```ruby
cookies[:test] = { value: "hello world", path: "/pun/sys/myjobs/test" }
```