### PR TITLE
add page_title_prefix

### DIFF
--- a/lib/ood_appkit/configuration.rb
+++ b/lib/ood_appkit/configuration.rb
@@ -125,13 +125,7 @@ module OodAppkit
 
       self.enable_log_formatter = ::Rails.env.production?
 
-      self.page_title_prefix  = if ! ENV['PAGE_TITLE_PREFIX'].nil?
-                                  ENV['PAGE_TITLE_PREFIX'].to_s
-                                elsif ENV['OOD_DASHBOARD_TITLE'].nil?
-                                  ENV['OOD_DASHBOARD_TITLE'].to_s
-                                else
-                                  'Open OnDemand'
-                                end
+      self.page_title_prefix = (ENV['PAGE_TITLE_PREFIX'] || ENV['OOD_DASHBOARD_TITLE'] || 'Open OnDemand').to_s
     end
 
     private

--- a/lib/ood_appkit/configuration.rb
+++ b/lib/ood_appkit/configuration.rb
@@ -57,6 +57,10 @@ module OodAppkit
     # @return [boolean] whether to use OodAppkit log formatting in production
     attr_accessor :enable_log_formatter
 
+    # Prefix for Page titles for Accessiblity disambiguation
+    # @return [String] The page title prefix
+    attr_accessor :page_title_prefix
+
     # Customize configuration for this object.
     # @yield [self]
     def configure
@@ -98,7 +102,7 @@ module OodAppkit
         base_url: ENV['OOD_FILES_URL']   || '/pun/sys/files'
       )
       self.editor    = Urls::Editor.new(
-        title:    ENV['OOD_EDITOR_TITLE'] || 'Editor',
+        title:    ENV['OOD_EDITOR_TITLE'] || 'File Editor',
         base_url: ENV['OOD_EDITOR_URL']   || '/pun/sys/file-editor'
       )
 
@@ -120,6 +124,14 @@ module OodAppkit
       ENV.each {|k, v| /^BOOTSTRAP_(?<name>.+)$/ =~ k ? self.bootstrap[name.downcase] = v : nil}
 
       self.enable_log_formatter = ::Rails.env.production?
+
+      self.page_title_prefix  = if ! ENV['PAGE_TITLE_PREFIX'].nil?
+                                  ENV['PAGE_TITLE_PREFIX'].to_s
+                                elsif ENV['OOD_DASHBOARD_TITLE'].nil?
+                                  ENV['OOD_DASHBOARD_TITLE'].to_s
+                                else
+                                  'Open OnDemand'
+                                end
     end
 
     private

--- a/ood_appkit.gemspec
+++ b/ood_appkit.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |s|
   s.add_dependency "lograge", "~>0.3"
 
   s.add_development_dependency "sqlite3"
+  s.add_development_dependency "climate_control", "~> 0.2.0"
 end

--- a/test/ood_appkit/configuration_test.rb
+++ b/test/ood_appkit/configuration_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+require 'ood_appkit'
+require 'climate_control'
+
+class ConfigurationTest < ActiveSupport::TestCase
+
+  test "default page_title_prefix" do
+    # not sure how to get the rails magic to work here
+    OodAppkit.set_default_configuration
+    assert_equal "Open OnDemand", OodAppkit.page_title_prefix # default prefix
+  end
+
+  test "page_title_prefix set through OOD_DASHBOARD_TITLE" do
+    ClimateControl.modify OOD_DASHBOARD_TITLE: 'VT OnDemand' do
+      OodAppkit.set_default_configuration
+      assert_equal "VT OnDemand", OodAppkit.page_title_prefix
+    end
+  end
+
+  test "page_title_prefix set through PAGE_TITLE_PREFIX" do
+    ClimateControl.modify PAGE_TITLE_PREFIX: 'OSC OnDemand' do
+      OodAppkit.set_default_configuration
+      assert_equal "OSC OnDemand", OodAppkit.page_title_prefix
+    end
+  end
+
+  test "page_title_prefix set through PAGE_TITLE_PREFIX with OOD_DASHBOARD_TITLE also set" do
+    # uses PAGE_TITLE_PREFIX with higher precedence
+    ClimateControl.modify OOD_DASHBOARD_TITLE: 'VT OnDemand', PAGE_TITLE_PREFIX: 'OSC OnDemand' do
+      OodAppkit.set_default_configuration
+      assert_equal "OSC OnDemand", OodAppkit.page_title_prefix # default prefix
+    end
+  end
+
+end


### PR DESCRIPTION
Add page_title_prefix for use in apps to prefix html titles to disambiguate them. So 'Dashboard' can become "#{page_title_prefix} Dashboard" which would evaluate to "OSC OnDemand Dashboard" for OSC.

This is to help enable this downstream ondemand issue https://github.com/OSC/ondemand/issues/674.