### PR TITLE
Add filesystem parameter to files and editor URLs

### DIFF
--- a/lib/ood_appkit/urls/editor.rb
+++ b/lib/ood_appkit/urls/editor.rb
@@ -4,7 +4,7 @@ module OodAppkit
     class Editor < Url
       # @param (see Url#initialize)
       # @param edit_url [#to_s] the URL used to request the file editor api
-      def initialize(edit_url: '/edit', template: '{/url*}{+path}', **kwargs)
+      def initialize(edit_url: '/edit', template: '{/url*}{/fs}{+path}', **kwargs)
         super(template: template, **kwargs)
         @edit_url = parse_url_segments(edit_url.to_s)
       end
@@ -13,13 +13,15 @@ module OodAppkit
       # @param opts [#to_h] the available options for this method
       # @option opts [#to_s, nil] :path ("") The absolute path to the file on
       #   the filesystem
+      # @option opts [#to_s, nil] :fs ("") The filesystem for the path
       # @return [Addressable::URI] absolute url to access path in file editor
       #   api
       def edit(opts = {})
         opts = opts.to_h.compact.symbolize_keys
 
         path = opts.fetch(:path, "").to_s
-        @template.expand url: @base_url + @edit_url, path: path
+        fs = opts.fetch(:fs, "fs").to_s
+        @template.expand url: @base_url + @edit_url, fs: fs, path: path
       end
     end
   end

--- a/lib/ood_appkit/urls/files.rb
+++ b/lib/ood_appkit/urls/files.rb
@@ -5,7 +5,7 @@ module OodAppkit
       # @param (see Url#initialize)
       # @param fs_url [#to_s] the URL used to request a filesystem view in the app
       # @param api_url [#to_s] the URL used to request the app's api
-      def initialize(fs_url: '/fs', api_url: '/api/v1/fs', template: '{/url*}{+path}', **kwargs)
+      def initialize(fs_url: '', api_url: '/api/v1', template: '{/url*}{/fs}{+path}', **kwargs)
         super(template: template, **kwargs)
         @fs_url  = parse_url_segments(fs_url.to_s)
         @api_url = parse_url_segments(api_url.to_s)
@@ -15,24 +15,28 @@ module OodAppkit
       # @param opts [#to_h] the available options for this method
       # @option opts [#to_s, nil] :path ("") The absolute path to the file on
       #   the filesystem
+      # @option opts [#to_s, nil] :fs ("") The filesystem for the path
       # @return [Addressable::URI] absolute url to access path in file app
       def url(opts = {})
         opts = opts.to_h.compact.symbolize_keys
 
         path = opts.fetch(:path, "").to_s
-        @template.expand url: @base_url + @fs_url, path: path
+        fs = opts.fetch(:fs, "fs").to_s
+        @template.expand url: @base_url + @fs_url, fs: fs, path: path
       end
 
       # URL to access this app's API for a given absolute file path
       # @param opts [#to_h] the available options for this method
       # @option opts [#to_s, nil] :path ("") The absolute path to the file on
       #   the filesystem
+      # @option opts [#to_s, nil] :fs ("") The filesystem for the path
       # @return [Addressable::URI] absolute url to access path in files app api
       def api(opts = {})
         opts = opts.to_h.compact.symbolize_keys
 
         path = opts.fetch(:path, "").to_s
-        @template.expand url: @base_url + @api_url, path: path
+        fs = opts.fetch(:fs, "fs").to_s
+        @template.expand url: @base_url + @api_url, fs: fs, path: path
       end
     end
   end

--- a/test/ood_appkit_test.rb
+++ b/test/ood_appkit_test.rb
@@ -23,6 +23,23 @@ class OodAppkitTest < ActiveSupport::TestCase
 
     assert_equal "/f/fs/nfs/17/efranz/ood_dev", f.url(path: "/nfs/17/efranz/ood_dev").to_s
     assert_equal "/f/fs/nfs/17/efranz/ood_dev", f.url(path: Pathname.new("/nfs/17/efranz/ood_dev")).to_s
+
+    assert_equal "/f/s3/mybucket/foo", f.url(path: "/mybucket/foo", fs: "s3").to_s
+    assert_equal "/f/s3/mybucket/foo", f.url(path: Pathname.new("/mybucket/foo"), fs: "s3").to_s
+
+    assert_equal "/f/api/v1/fs/foo/bar", f.api(path: "/foo/bar").to_s
+    assert_equal "/f/api/v1/s3/foo/bar", f.api(path: "/foo/bar", fs: "s3").to_s
+
+    assert_equal "/f/Remote%200.-_/foo/bar", f.url(path: "/foo/bar", fs: "Remote 0.-_").to_s
   end
 
+  test "editor urls" do
+    e = OodAppkit::Urls::Editor.new(base_url: "/f")
+
+    assert_equal "/f/edit/fs/foo/bar", e.edit(path: "/foo/bar").to_s
+    assert_equal "/f/edit/fs/foo/bar", e.edit(path: Pathname.new("/foo/bar")).to_s
+    assert_equal "/f/edit/s3/foo/bar", e.edit(path: "/foo/bar", fs: "s3").to_s
+
+    assert_equal "/f/edit/Remote%200.-_/foo/bar", e.edit(path: "/foo/bar", fs: "Remote 0.-_").to_s
+  end
 end


### PR DESCRIPTION
Fixes #67.
Seems to be many possible approaches to solving this, but I decided to add the filesystem to the URL template. Defaults to `fs`.