### PR TITLE
Handle non-UTF-8 in LogFormatter

### DIFF
--- a/lib/ood_appkit/log_formatter.rb
+++ b/lib/ood_appkit/log_formatter.rb
@@ -7,7 +7,7 @@ module OodAppkit
     def call(severity, timestamp, progname, msg)
       severity_d = severity ? severity[0,5].rjust(5).upcase : "UNKNO"
       timestamp_d = timestamp ? timestamp.localtime : Time.now.localtime
-      msg_d = (String === msg ? msg.strip.inspect : msg.inspect)
+      msg_d = (String === msg ? msg.encode("UTF-8", :invalid => :replace, :undef => :replace).strip.inspect : msg.inspect)
 
       "[#{timestamp_d} #{progname}] #{severity_d} #{msg_d}\n"
     end


### PR DESCRIPTION
The LogFormatter previously raised "invalid byte sequence in UTF-8 (ArgumentError)" for any non-UTF-8 logging due to strip not supporting non-UTF-8 strings.
This PR encodes the strings as UTF-8 before running strip on them.

See https://github.com/OSC/ondemand/issues/4118 for more context on the issues this solves.